### PR TITLE
Add integration tests and enhance Makefile for YAML configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,68 @@ GOARCH ?= arm64
 
 # Directories
 SRC_DIR=./...
+CONFIG_DIR=tests/configs
 
 # Build the project
 build: tidy
 	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOBUILD) -o $(BINARY_NAME) $(SRC_DIR)
 
-# Run tests
+# Run unit tests
 test:
 	$(GOTEST) -v ./...
+
+# Run integration tests (requires root privileges)
+test-integration:
+	$(GOTEST) -v -run TestICMPIntegration ./...
+
+# Run YAML-based integration tests
+test-yaml: build
+	@echo "Running YAML-based ICMP tests..."
+	@for config in $(CONFIG_DIR)/*.yaml; do \
+		echo "Running test with config: $$config"; \
+		sudo ./$(BINARY_NAME) -config $$config || echo "Test failed: $$config"; \
+		echo ""; \
+	done
+
+# Run specific test config
+test-config: build
+	@if [ -z "$(CONFIG)" ]; then \
+		echo "Usage: make test-config CONFIG=tests/configs/test_basic.yaml"; \
+		exit 1; \
+	fi
+	sudo ./$(BINARY_NAME) -config $(CONFIG)
+
+# Test comprehensive functionality (basic + payload sizes)
+test-comprehensive: build
+	sudo ./$(BINARY_NAME) -config $(CONFIG_DIR)/comprehensive.yaml
+
+# Test DF bit functionality
+test-df: build
+	sudo ./$(BINARY_NAME) -config $(CONFIG_DIR)/df_bit.yaml
+
+# Test localhost functionality
+test-localhost: build
+	sudo ./$(BINARY_NAME) -config $(CONFIG_DIR)/localhost.yaml
+
+# Run all YAML tests with summary
+test-all-yaml: build
+	@echo "=== Running All YAML Test Configurations ==="
+	@passed=0; failed=0; \
+	for config in $(CONFIG_DIR)/*.yaml; do \
+		echo "Running: $$config"; \
+		if sudo ./$(BINARY_NAME) -config $$config >/dev/null 2>&1; then \
+			echo "✓ PASSED: $$config"; \
+			passed=$$((passed + 1)); \
+		else \
+			echo "✗ FAILED: $$config"; \
+			failed=$$((failed + 1)); \
+		fi; \
+	done; \
+	echo ""; \
+	echo "=== Test Summary ==="; \
+	echo "Passed: $$passed"; \
+	echo "Failed: $$failed"; \
+	echo "Total:  $$((passed + failed))"
 
 # Format the code
 fmt:
@@ -36,5 +90,29 @@ tidy:
 clean:
 	rm -f $(BINARY_NAME)
 
+# Show available test configs
+list-configs:
+	@echo "Available test configurations:"
+	@ls -1 $(CONFIG_DIR)/*.yaml | sed 's|$(CONFIG_DIR)/||'
+
 # Default target
 all: fmt tidy build test
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  build            - Build the binary"
+	@echo "  test             - Run unit tests"
+	@echo "  test-integration - Run Go integration tests (requires root)"
+	@echo "  test-yaml        - Run all YAML-based tests (requires root)"
+	@echo "  test-config      - Run specific config: make test-config CONFIG=path/to/config.yaml"
+	@echo "  test-comprehensive - Run comprehensive functionality tests"
+	@echo "  test-df          - Run DF bit tests"
+	@echo "  test-localhost   - Run localhost tests"
+	@echo "  test-all-yaml    - Run all YAML tests with summary"
+	@echo "  list-configs     - List available test configurations"
+	@echo "  fmt              - Format code"
+	@echo "  clean            - Clean build artifacts"
+	@echo "  help             - Show this help"
+
+.PHONY: build test test-integration test-yaml test-config test-comprehensive test-df test-localhost test-all-yaml fmt tidy clean list-configs help all

--- a/README.md
+++ b/README.md
@@ -1,9 +1,96 @@
+# ICMP Test Tool
+
+A Go-based tool for testing ICMP packet transmission and reception. Supports payload size, DF bit configuration, and fragmentation behavior verification.
+
 ## Build
-```
-make
+```bash
+make build
 ```
 
-## Run test
+## Running Tests
+
+### Using YAML Configuration Files
+
+#### Available Configuration Files
+```bash
+make list-configs
 ```
-sudo ./icmp-test -config example/config.yaml
+
+#### Individual Test Execution
+```bash
+# Comprehensive tests (basic functionality + payload sizes)
+make test-comprehensive
+
+# DF bit tests
+make test-df
+
+# Localhost tests
+make test-localhost
+
+# Specify a specific configuration file
+make test-config CONFIG=tests/configs/comprehensive.yaml
+```
+
+#### Run All YAML Tests
+```bash
+# Run all configuration files
+make test-all-yaml
+
+# With detailed output
+make test-yaml
+```
+
+### Go Integration Tests
+
+```bash
+# Programmatic tests in Go
+sudo make test-integration
+
+# Regular unit tests (no root privileges required)
+make test
+```
+
+### Manual Execution
+```bash
+sudo ./icmp-test -config tests/configs/comprehensive.yaml
+```
+
+## Test Configuration
+
+### tests/configs/
+
+- `comprehensive.yaml`: Comprehensive configuration for basic functionality and payload size tests
+- `df_bit.yaml`: DF bit behavior tests
+- `localhost.yaml`: Localhost environment tests
+
+### Configuration Example
+
+```yaml
+general:
+  output: "text"
+  parallelism: 1
+  tos: 0x00
+  interface_name: "en0"
+  set_df_bit: false
+
+tests:
+  - name: "Basic Echo Test"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "3s"
+    payload_size: 32
+```
+
+## For Developers
+
+### Choosing Test Execution Methods
+
+1. **YAML Configuration Files**: Visual and easy to understand, suitable for CI/CD pipelines
+2. **Go Integration Tests**: Programmatic control, suitable for complex test logic
+
+### Makefile Targets
+
+```bash
+make help  # Display available commands
 ```

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,11 +1,10 @@
 general:
-  output: "text"  # Output format "text" or "json" (optional)
+  output: "json"  # Output format "text" or "json" (optional)
   parallelism: 1  # Number of concurrent tests (optional)
   tos: 0x00  # Type of Service (TOS) field in IP header (optional)
   interface_name: "eth0"  # Network interface name (optional)
   interface_address: "192.168.0.1" # Network interface address (optional)
   result_filter:
-    - "PASSED"
     - "FAILED"
 
 tests:
@@ -14,3 +13,11 @@ tests:
     request_type: "echo" # "echo" or "timestamp"
     expected_result: "response" # "response" or "timeout"
     timeout: "2s"  # Timeout for the test (default 1s)
+    payload_size: 64  # ICMP echo payload size in bytes (default 32)
+
+  - name: "Large Payload Test (requires fragmentation)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "5s"
+    payload_size: 2000  # Large payload that will be fragmented

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestICMPIntegration runs various ICMP tests that were previously defined in YAML files
+func TestICMPIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	// Note: These tests require root privileges to run
+	testCases := []struct {
+		name       string
+		config     Config
+		shouldPass bool
+	}{
+		{
+			name: "Basic Echo Test",
+			config: Config{
+				General: generalConfig{
+					Output:      "text",
+					Parallelism: 1,
+					TOS:         0,
+					SetDFBit:    false,
+				},
+				Tests: []testInput{
+					{
+						Name:           "Basic Echo to Google DNS",
+						Destination:    "8.8.8.8",
+						RequestType:    "echo",
+						ExpectedResult: "response",
+						Timeout:        stringPtr("3s"),
+						PayloadSize:    intPtr(32),
+					},
+				},
+			},
+			shouldPass: true,
+		},
+		{
+			name: "Large Payload Test",
+			config: Config{
+				General: generalConfig{
+					Output:      "text",
+					Parallelism: 1,
+					TOS:         0,
+					SetDFBit:    false,
+				},
+				Tests: []testInput{
+					{
+						Name:           "Large payload - 1000 bytes",
+						Destination:    "8.8.8.8",
+						RequestType:    "echo",
+						ExpectedResult: "response",
+						Timeout:        stringPtr("5s"),
+						PayloadSize:    intPtr(1000),
+					},
+					{
+						Name:           "Large payload - 1400 bytes",
+						Destination:    "8.8.8.8",
+						RequestType:    "echo",
+						ExpectedResult: "response",
+						Timeout:        stringPtr("5s"),
+						PayloadSize:    intPtr(1400),
+					},
+				},
+			},
+			shouldPass: true,
+		},
+		{
+			name: "DF Bit Test",
+			config: Config{
+				General: generalConfig{
+					Output:      "text",
+					Parallelism: 1,
+					TOS:         0,
+					SetDFBit:    true, // DF bit enabled
+				},
+				Tests: []testInput{
+					{
+						Name:           "DF bit with large payload (should timeout)",
+						Destination:    "8.8.8.8",
+						RequestType:    "echo",
+						ExpectedResult: "timeout",
+						Timeout:        stringPtr("3s"),
+						PayloadSize:    intPtr(2000),
+					},
+				},
+			},
+			shouldPass: true,
+		},
+		{
+			name: "Localhost Test",
+			config: Config{
+				General: generalConfig{
+					Output:      "text",
+					Parallelism: 1,
+					TOS:         0,
+					SetDFBit:    false,
+				},
+				Tests: []testInput{
+					{
+						Name:           "Localhost echo",
+						Destination:    "127.0.0.1",
+						RequestType:    "echo",
+						ExpectedResult: "response",
+						Timeout:        stringPtr("2s"),
+						PayloadSize:    intPtr(32),
+					},
+					{
+						Name:           "Localhost large payload",
+						Destination:    "127.0.0.1",
+						RequestType:    "echo",
+						ExpectedResult: "response",
+						Timeout:        stringPtr("2s"),
+						PayloadSize:    intPtr(2000),
+					},
+				},
+			},
+			shouldPass: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set up network interface and source IP
+			config := setupTestConfig(t, &tc.config)
+
+			// Run all tests in this configuration
+			allPassed := true
+			for i, testInput := range config.Tests {
+				// Parse timeout
+				var timeout time.Duration = 2 * time.Second
+				if testInput.Timeout != nil {
+					if d, err := time.ParseDuration(*testInput.Timeout); err == nil {
+						timeout = d
+					}
+				}
+
+				// Parse request type
+				reqType, err := parseICMPRequestType(testInput.RequestType)
+				if err != nil {
+					t.Errorf("Invalid request type %s: %v", testInput.RequestType, err)
+					continue
+				}
+
+				// Set payload size
+				payloadSize := defaultPayloadSize
+				if testInput.PayloadSize != nil {
+					payloadSize = *testInput.PayloadSize
+				}
+
+				test := Test{
+					Name:           testInput.Name,
+					Destination:    testInput.Destination,
+					ID:             pid,
+					Seq:            i + 1,
+					RequestType:    reqType,
+					Timeout:        timeout,
+					ExpectedResult: testInput.ExpectedResult,
+					PayloadSize:    payloadSize,
+				}
+
+				result := runICMPTest(config, test)
+
+				if result.Status != "PASSED" {
+					if tc.shouldPass {
+						t.Errorf("Test %s failed: %s", result.Name, result.Details)
+					}
+					allPassed = false
+				} else {
+					t.Logf("Test %s passed: %s", result.Name, result.Details)
+				}
+			}
+
+			if tc.shouldPass && !allPassed {
+				t.Errorf("Expected all tests to pass, but some failed")
+			}
+		})
+	}
+}
+
+// Helper functions
+func stringPtr(s string) *string {
+	return &s
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func setupTestConfig(t *testing.T, config *Config) *Config {
+	// Determine if this config uses localhost destinations
+	usesLocalhost := false
+	for _, test := range config.Tests {
+		if test.Destination == "127.0.0.1" || test.Destination == "::1" || test.Destination == "localhost" {
+			usesLocalhost = true
+			break
+		}
+	}
+
+	var ifaceName, ipStr string
+	if usesLocalhost {
+		// Use loopback interface for localhost tests
+		ifaceName, ipStr = getLocalInterfaceAndIP(t)
+	} else {
+		// Use external interface for external destinations
+		ifaceName, ipStr = getValidInterfaceAndIP(t)
+	}
+
+	iface, err := getIfaceFromInterfaceName(ifaceName)
+	if err != nil {
+		t.Fatalf("Failed to get interface %s: %v", ifaceName, err)
+	}
+
+	config.General.Interface = *iface
+	config.General.SourceIPAddress = parseIP(ipStr)
+	config.General.InterfaceName = ifaceName
+	config.General.SourceIPAddressString = ipStr
+
+	return config
+}
+
+func parseIP(ipStr string) net.IP {
+	return net.ParseIP(ipStr)
+}

--- a/tests/configs/comprehensive.yaml
+++ b/tests/configs/comprehensive.yaml
@@ -1,0 +1,54 @@
+# Comprehensive ICMP test configuration
+# Includes basic functionality, payload size, and DF bit tests
+
+general:
+  output: "text"
+  parallelism: 1
+  tos: 0x00
+  interface_name: "en0"
+  set_df_bit: false
+
+tests:
+  # Basic functionality tests
+  - name: "Basic Echo Test - Google DNS"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "3s"
+    payload_size: 32
+
+  - name: "Basic Echo Test - Localhost"
+    dest: "127.0.0.1"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "2s"
+    payload_size: 32
+
+  # Payload size tests
+  - name: "Small Payload (64 bytes)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "3s"
+    payload_size: 64
+
+  - name: "Medium Payload (500 bytes)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "3s"
+    payload_size: 500
+
+  - name: "Large Payload (1400 bytes)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "5s"
+    payload_size: 1400
+
+  - name: "Very Large Payload (2000 bytes) - may timeout"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "timeout"  # Large payloads are expected to timeout
+    timeout: "5s"
+    payload_size: 2000

--- a/tests/configs/df_bit.yaml
+++ b/tests/configs/df_bit.yaml
@@ -1,0 +1,40 @@
+# DF bit specific test configuration
+# Verifies behavior when DF bit is set
+
+general:
+  output: "text"
+  parallelism: 1
+  tos: 0x00
+  interface_name: "en0"
+  set_df_bit: true  # Set DF bit
+
+tests:
+  # DF bit + small payload (should succeed)
+  - name: "DF Bit - Small Payload (should succeed)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "3s"
+    payload_size: 32
+
+  - name: "DF Bit - Medium Payload (should succeed)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "3s"
+    payload_size: 1000
+
+  # DF bit + large payload (may timeout)
+  - name: "DF Bit - Large Payload (may timeout)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "timeout"  # Expect timeout
+    timeout: "3s"
+    payload_size: 2000
+
+  - name: "DF Bit - Very Large Payload (may timeout)"
+    dest: "8.8.8.8"
+    request_type: "echo"
+    expected_result: "timeout"  # Expect timeout
+    timeout: "3s"
+    payload_size: 3000

--- a/tests/configs/localhost.yaml
+++ b/tests/configs/localhost.yaml
@@ -1,0 +1,24 @@
+# Localhost test configuration
+# Local tests with minimal network latency
+
+general:
+  output: "text"
+  parallelism: 1
+  tos: 0x00
+  interface_name: "lo0"  # Local interface
+  set_df_bit: false
+
+tests:
+  - name: "Localhost - Basic Echo"
+    dest: "127.0.0.1"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "1s"
+    payload_size: 32
+
+  - name: "Localhost - Large Payload"
+    dest: "127.0.0.1"
+    request_type: "echo"
+    expected_result: "response"
+    timeout: "2s"
+    payload_size: 2000


### PR DESCRIPTION
This pull request introduces significant enhancements to the ICMP testing tool, including new test configurations, payload size support, and DF (Don't Fragment) bit handling. It also adds integration tests and updates documentation to reflect the new features. Below is a categorized summary of the most important changes:

### New Testing Features
* Added support for specifying ICMP payload size in the configuration (`payload_size`) and implemented validation for payload size values. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R62) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R696-R707)
* Introduced DF bit handling, allowing users to set the "Don't Fragment" flag in the IP header for advanced testing scenarios. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R29) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R211-R225)

### Makefile Enhancements
* Added new Makefile targets for running YAML-based tests, integration tests, and specific test configurations.
* Introduced a `list-configs` target to display available YAML test configurations and a `help` target to summarize all Makefile commands.

### Integration Tests
* Added a new `TestICMPIntegration` function in `integration_test.go` to programmatically validate ICMP functionality with various configurations, including payload size and DF bit scenarios.

### Configuration and Defaults
* Updated the example configuration file to include payload size and DF bit options, along with new test cases like large payload and DF bit tests. [[1]](diffhunk://#diff-c071e03510b2c57e193a44503fd9528a785f0f411497cc75841a9f8d0b1ac622L2-L8) [[2]](diffhunk://#diff-c071e03510b2c57e193a44503fd9528a785f0f411497cc75841a9f8d0b1ac622R16-R23)
* Introduced default values for payload size (`32 bytes`) and DF bit (`false`) in the codebase. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R94-R100) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R490-R495)

### Documentation Updates
* Expanded the `README.md` to include detailed instructions on running tests, using YAML configurations, and understanding the new features like payload size and DF bit handling.